### PR TITLE
PML-299 MIT license and third party notice for reproduced papers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Quandela
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ and complements the online documentation available at:
 
 Each paper reproduction is designed to be accessible, well-documented, and easy to extend. Contributions are welcome!
 
+## License
+
+Unless otherwise noted, original code in this repository is released under the
+MIT License. See the root [LICENSE](LICENSE).
+
+This repository also includes or adapts third-party material. Files copied or
+derived from upstream projects keep their original license headers and remain
+subject to those terms. See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)
+and any per-file or per-directory notices for details.
+
 
 ## Papers reproduced:
 | Paper | Reproduction |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,53 @@
+# Third-Party Notices
+
+This repository contains original code released under the MIT License in the
+root `LICENSE` file. It also includes or adapts material from third-party
+projects.
+
+This file is informational and does not replace notices in individual source
+files or subdirectories. If a file has its own license header, or a directory
+ships with its own `LICENSE` or `NOTICE` file, that notice controls for the
+material it covers.
+
+## Major upstream projects
+
+### Qiskit
+
+- Upstream: <https://github.com/Qiskit/qiskit>
+- License: Apache License 2.0
+- Notes: some gate-based reproductions may include code adapted from Qiskit or
+  preserve Qiskit-compatible structures. Keep Apache notices where present.
+
+### PennyLane
+
+- Upstream: <https://github.com/PennyLaneAI/pennylane>
+- License: Apache License 2.0
+- Notes: some gate-based reproductions may include code adapted from PennyLane
+  or preserve PennyLane-compatible structures. Keep Apache notices where
+  present.
+
+### MerLin
+
+- Upstream: <https://github.com/merlinquantum/merlin>
+- License: MIT
+- Notes: this repository is part of the MerLin ecosystem and includes code
+  written for or adapted from MerLin.
+
+## Additional embedded or legacy material
+
+- Some archived or legacy directories include their own `LICENSE` files. Those
+  licenses continue to apply within those directories.
+- Example: `papers/qSSL/lib/qnn/` contains files that retain an MIT header from
+  upstream material, and `legacy/` contains bundled code with directory-local
+  licenses.
+- Example: some files under `papers/shared/` retain Apache 2.0 headers from
+  upstream material.
+
+## Practical rule
+
+- The root `LICENSE` applies to original repository code unless another notice
+  says otherwise.
+- Per-file headers and directory-local `LICENSE` or `NOTICE` files apply to the
+  specific third-party material they cover.
+- When redistributing this repository, preserve the root MIT license and all
+  applicable third-party notices.


### PR DESCRIPTION
Adding 

- a LICENSE.md that should be recognized by github as a MIT License
- a Third party notice acknowledges the presence of third party code (for example in the qSSL, the qiskit code is under MIT License from Ben Jaderberg)
- an explanation in the README
