### PR TITLE
Align Ruff workflow with pre-commit

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: '3.9'
     
     - name: Install ruff
-      run: pip install ruff
+      run: pip install ruff==0.4.4
     
     - name: Run ruff linter
       run: ruff check .

--- a/papers/DQNN/lib/boson_sampler.py
+++ b/papers/DQNN/lib/boson_sampler.py
@@ -42,9 +42,9 @@ class BosonSampler:
         """
         self.m = m
         self.n = n
-        assert n <= m, (
-            "Got more modes than photons, can only input 0 or 1 photon per mode"
-        )
+        assert (
+            n <= m
+        ), "Got more modes than photons, can only input 0 or 1 photon per mode"
         self.quantum_layer = self.create_quantum_layer(qnn_layers=qnn_layers)
 
     @property

--- a/papers/HQNN_MythOrReality/scripts/run_classical_baseline.py
+++ b/papers/HQNN_MythOrReality/scripts/run_classical_baseline.py
@@ -19,7 +19,9 @@ from models.classical_baseline import (
     BaselineConfig,
     evaluate_architecture,
     generate_mlp_architectures,
-)  # noqa: E402
+)
+
+# noqa: E402
 from utils.io import save_experiment_results  # noqa: E402
 from utils.training import count_parameters  # noqa: E402
 

--- a/papers/HQPINN/lib/DEE/dee_hy_m.py
+++ b/papers/HQPINN/lib/DEE/dee_hy_m.py
@@ -119,7 +119,10 @@ def run(mode="train", backend="sim:ascella", model_size="10-4-1"):
                     try:
                         model = load_model(
                             existing_ckpt,
-                            lambda processor=None, n_photons=n_photons, width=width, layers=layers: (
+                            lambda processor=None,
+                            n_photons=n_photons,
+                            width=width,
+                            layers=layers: (
                                 ClassicalInterferometerPinn(
                                     n_photons=n_photons,
                                     hidden_width=width,

--- a/papers/HQPINN/lib/DEE/dee_hy_pl.py
+++ b/papers/HQPINN/lib/DEE/dee_hy_pl.py
@@ -127,7 +127,10 @@ def run(mode="train", backend="sim:ascella", model_size="10-4-2"):
                     try:
                         model = load_model(
                             existing_ckpt,
-                            lambda processor=None, q_layers=q_layers, width=width, layers=layers: (
+                            lambda processor=None,
+                            q_layers=q_layers,
+                            width=width,
+                            layers=layers: (
                                 ClassicalPennyLanePinn(
                                     q_layers=q_layers,
                                     hidden_width=width,

--- a/papers/HQPINN/lib/DHO/core_dho.py
+++ b/papers/HQPINN/lib/DHO/core_dho.py
@@ -157,7 +157,6 @@ def train_oscillator_pinn(
         [nn.Module, torch.Tensor], tuple[torch.Tensor, torch.Tensor, torch.Tensor]
     ] = oscillator_loss,
 ) -> None:
-
     os.makedirs(out_dir, exist_ok=True)
 
     png_path = os.path.join(out_dir, f"dho-{model_label}_{run_id}.png")

--- a/papers/HQPINN/lib/SEE/core_see.py
+++ b/papers/HQPINN/lib/SEE/core_see.py
@@ -683,7 +683,6 @@ def save_density_plot(
     run_id: str,
     backend: str,
 ) -> str:
-
     model.eval()
 
     nx, nt = SEE_NX_SAMPLES, SEE_NT_SAMPLES

--- a/papers/HQPINN/lib/SEE/see_hy_m.py
+++ b/papers/HQPINN/lib/SEE/see_hy_m.py
@@ -156,7 +156,10 @@ def run(
                     try:
                         model = load_model(
                             existing_ckpt,
-                            lambda processor=None, n_photons=n_photons, width=width, layers=layers: (
+                            lambda processor=None,
+                            n_photons=n_photons,
+                            width=width,
+                            layers=layers: (
                                 ClassicalInterferometerPinn(
                                     n_photons=n_photons,
                                     hidden_width=width,

--- a/papers/HQPINN/lib/SEE/see_hy_pl.py
+++ b/papers/HQPINN/lib/SEE/see_hy_pl.py
@@ -155,7 +155,10 @@ def run(
                     try:
                         model = load_model(
                             existing_ckpt,
-                            lambda processor=None, q_layers=q_layers, width=width, layers=layers: (
+                            lambda processor=None,
+                            q_layers=q_layers,
+                            width=width,
+                            layers=layers: (
                                 ClassicalPennyLanePinn(
                                     q_layers=q_layers,
                                     hidden_width=width,

--- a/papers/HQPINN/lib/TAF/generate_aerofoil_training_sets.py
+++ b/papers/HQPINN/lib/TAF/generate_aerofoil_training_sets.py
@@ -191,7 +191,6 @@ X_wall = np.stack([Xw_x, Xw_y], axis=-1)
 
 # Compute outward unit normals along the airfoil boundary
 def compute_normals(xs, ys):
-
     # Compute numerical tangent vector along the curve
     # This is derivative along the contour parameter (not ∂/∂x or ∂/∂y)
     dx = np.gradient(xs)
@@ -292,7 +291,6 @@ X_bot = np.stack([x_topbot, np.full_like(x_topbot, TAF_Y_MIN)], axis=-1)
 #   If the number of intersections is odd → point is inside.
 #   If even → point is outside.
 def point_in_polygon(xy_points, poly_x, poly_y):
-
     # Extract x and y coordinates of test points
     x = xy_points[:, 0]
     y = xy_points[:, 1]

--- a/papers/QCNN_ID/tests/test_models.py
+++ b/papers/QCNN_ID/tests/test_models.py
@@ -55,7 +55,6 @@ def test_qcnn_classifier_forward_and_grad():
 
 @pytest.mark.parametrize("n_modes,n_photons", [(4, 2), (6, 3)])
 def test_merlin_classifier_forward(n_modes, n_photons):
-
     model = PhotonicClassifier(
         n_modes=n_modes,
         n_photons=n_photons,

--- a/papers/QCNN_data_classification/lib/runner.py
+++ b/papers/QCNN_data_classification/lib/runner.py
@@ -125,7 +125,6 @@ def _prepare_models(
 def _plot_training_figures(
     run_dir: Path, variant_histories: dict[str, list[dict[str, list[float]]]]
 ) -> None:
-
     matplotlib.use("Agg")
 
     def _save_metric(metric_key: str, ylabel: str, title: str, filename: Path) -> None:

--- a/papers/QORC/lib/lib_qorc_encoding_and_linear_training.py
+++ b/papers/QORC/lib/lib_qorc_encoding_and_linear_training.py
@@ -128,9 +128,9 @@ def create_quantum_layer_for_ascella(n_photons, logger):
     logger.info("MerLin QuantumLayer creation:")
     qorc_output_size = math.comb(n_photons + n_modes - 1, n_photons)
 
-    assert n_photons <= n_modes, (
-        "Error with photons_input_mode: Bunching not possible for input state."
-    )
+    assert (
+        n_photons <= n_modes
+    ), "Error with photons_input_mode: Bunching not possible for input state."
     step = (n_modes - 1) / (n_photons - 1) if n_photons > 1 else 0
     qorc_input_state = [0] * n_modes
     for k in range(n_photons):
@@ -188,9 +188,9 @@ def create_qorc_quantum_layer(
 
     qorc_circuit = interferometer_1 // c_var // interferometer_2
 
-    assert n_photons <= n_modes, (
-        "Error with photons_input_mode: Bunching not possible for input state."
-    )
+    assert (
+        n_photons <= n_modes
+    ), "Error with photons_input_mode: Bunching not possible for input state."
     step = (n_modes - 1) / (n_photons - 1) if n_photons > 1 else 0
     qorc_input_state = [0] * n_modes
     for k in range(n_photons):

--- a/papers/QORC/tests/test_configs.py
+++ b/papers/QORC/tests/test_configs.py
@@ -31,6 +31,6 @@ def test_cli_schema_matches_defaults_path() -> None:
     assert cli_schema_path.exists(), "cli.json missing"
 
     runner_module = importlib.import_module("lib.runner")
-    assert hasattr(runner_module, "train_and_evaluate"), (
-        "Runner must expose train_and_evaluate()"
-    )
+    assert hasattr(
+        runner_module, "train_and_evaluate"
+    ), "Runner must expose train_and_evaluate()"

--- a/papers/QRNN/lib/perceval_export.py
+++ b/papers/QRNN/lib/perceval_export.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 def _build_qrb_circuit(*, kd: int, kh: int):
-
     kd = int(kd)
     kh = int(kh)
     m = kd + kh

--- a/papers/QRNN/tests/test_cli.py
+++ b/papers/QRNN/tests/test_cli.py
@@ -44,6 +44,6 @@ def test_train_and_evaluate_writes_artifact(tmp_path):
 
     assert (run_dir / "done.txt").exists(), "Expected completion marker to be created"
     assert (run_dir / "metrics.json").exists(), "Expected metrics to be saved"
-    assert (run_dir / "predictions.csv").exists(), (
-        "Expected predictions CSV to be saved"
-    )
+    assert (
+        run_dir / "predictions.csv"
+    ).exists(), "Expected predictions CSV to be saved"

--- a/papers/nn_embedding/lib/gate_based_model.py
+++ b/papers/nn_embedding/lib/gate_based_model.py
@@ -677,11 +677,13 @@ class NeuralEmbeddingGateBasedKernel(nn.Module):
 ########################################################################################################
 
 
-def create_paper_models() -> tuple[
-    NeuralEmbeddingGateBasedModel,
-    NeuralEmbeddingGateBasedModel,
-    NeuralEmbeddingGateBasedModel,
-]:
+def create_paper_models() -> (
+    tuple[
+        NeuralEmbeddingGateBasedModel,
+        NeuralEmbeddingGateBasedModel,
+        NeuralEmbeddingGateBasedModel,
+    ]
+):
     """Create the three gate-based model variants described in the paper.
 
     The returned models correspond to the architectures used across the gate-

--- a/papers/nn_embedding/tests/test_utils.py
+++ b/papers/nn_embedding/tests/test_utils.py
@@ -23,7 +23,9 @@ from papers.nn_embedding.utils.merlin_model_utils import (  # noqa: E402
     ordered_variable_params,
     rename_params_in_current_order,
     strip_simple_negation_expressions,
-)  # noqa: E402
+)
+
+# noqa: E402
 from papers.nn_embedding.utils.utils import (  # noqa: E402
     LinearLoss,
     TransparentModel,
@@ -106,7 +108,6 @@ def _component_params(component):
 
 
 def test_calculate_distance():
-
     plus_state = torch.tensor(0.5 * np.array([[1, 1], [1, 1]]))
     minus_state = torch.tensor(0.5 * np.array([[1, -1], [-1, 1]]))
     zero_state = torch.tensor(np.array([[1, 0], [0, 0]]))

--- a/papers/qSSL/lib/qnn/gradient_calculator.py
+++ b/papers/qSSL/lib/qnn/gradient_calculator.py
@@ -100,7 +100,7 @@ def get_parameter_shift_circuits(qnn, parameter_list, r):
 
 
 def get_finite_difference_circuits(qnn, parameter_list, eps):
-    if type(eps) is float:
+    if isinstance(eps, float):
         qc_plus_list, qc_minus_list = [], []
         for i in range(len(parameter_list)):
             shifted_params_plus = np.copy(parameter_list)

--- a/papers/shared/fock_state_expressivity/VQC_fourier_series/data.py
+++ b/papers/shared/fock_state_expressivity/VQC_fourier_series/data.py
@@ -60,9 +60,9 @@ def generate_dataset(cfg: dict) -> dict[str, torch.Tensor]:
         values += coeff * np.exp(1j * n * xs)
 
     ys = values.real  # Imaginary residuals are numerical noise only.
-    assert np.allclose(values.imag, 0, atol=1e-6), (
-        "Fourier series should evaluate to real values."
-    )
+    assert np.allclose(
+        values.imag, 0, atol=1e-6
+    ), "Fourier series should evaluate to real values."
 
     x_tensor = torch.tensor(xs, dtype=torch.float32).unsqueeze(-1)
     y_tensor = torch.tensor(ys, dtype=torch.float32)


### PR DESCRIPTION
Lock Ruff to v0.4.4 to align with the pre-commit file.
Current workflow downloads latest version of Ruff and checks with that, causing discrepancies between PRs