### PR TITLE
Adding CI smoke tests from original script

### DIFF
--- a/.github/workflows/smoke-test-new-papers.yml
+++ b/.github/workflows/smoke-test-new-papers.yml
@@ -68,6 +68,62 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Validate paper structure
+        if: steps.detect.outputs.papers != ''
+        run: |
+          set -euo pipefail
+
+          REQUIRED_FILES=(
+            "lib/runner.py"
+            "configs/defaults.json"
+            "cli.json"
+          )
+
+          VALIDATION_FAILED=0
+
+          for paper in ${{ steps.detect.outputs.papers }}; do
+            echo "::group::Validating structure for $paper"
+            PAPER_FAILED=0
+
+            for required_file in "${REQUIRED_FILES[@]}"; do
+              if [[ ! -f "papers/$paper/$required_file" ]]; then
+                echo "❌ MISSING: papers/$paper/$required_file"
+                PAPER_FAILED=1
+                VALIDATION_FAILED=1
+              else
+                echo "✓ Found: papers/$paper/$required_file"
+              fi
+            done
+
+            if [[ $PAPER_FAILED -eq 1 ]]; then
+              echo ""
+              echo "ERROR: Paper '$paper' does not follow the required structure."
+              echo ""
+              echo "Required files:"
+              printf '  - %s\n' "${REQUIRED_FILES[@]}"
+              echo ""
+              echo "Expected structure:"
+              cat << 'EOF'
+          papers/<paper_name>/
+          ├── lib/
+          │   └── runner.py          (entry point with train_and_evaluate function)
+          ├── configs/
+          │   └── defaults.json      (default runnable config)
+          └── cli.json               (paper-specific CLI schema)
+          EOF
+              echo ""
+              echo "See AGENTS.md section 'Repository Model' for more details."
+            fi
+
+            echo "::endgroup::"
+          done
+
+          if [[ $VALIDATION_FAILED -eq 1 ]]; then
+            echo ""
+            echo "::error::One or more papers failed structural validation."
+            exit 1
+          fi
+
       - name: Smoke test new papers
         if: steps.detect.outputs.papers != ''
         run: |

--- a/.github/workflows/smoke-test-new-papers.yml
+++ b/.github/workflows/smoke-test-new-papers.yml
@@ -1,0 +1,91 @@
+name: Smoke Test New Papers
+
+# Runs scripts/smoke_test_all_papers.sh against any paper folder newly added by a PR.
+# This verifies (per new paper): the venv/deps install cleanly, the default config
+# runs to completion within the script's timeout, and pytest passes.
+
+on:
+  pull_request:
+    branches: [ main, master ]
+    paths:
+      - 'papers/**'
+
+jobs:
+  smoke-test:
+    # Restrict to trusted authors (merlinquantum org members/owners) since this job
+    # installs arbitrary paper dependencies and executes their code on the runner.
+    if: contains(fromJSON('["MEMBER", "OWNER"]'), github.event.pull_request.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15 # this timeout could be adapted in the future (15 minutes can be quite large if many new papers are added in a single PR, but is a reasonable default for a single paper).
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Detect newly added paper folders
+        id: detect
+        run: |
+          set -euo pipefail
+
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          mapfile -t added_paths < <(git diff --name-status --diff-filter=A "$BASE_SHA" "$HEAD_SHA" -- papers/ | awk '{print $2}')
+
+          declare -A seen
+          new_papers=()
+          for path in "${added_paths[@]}"; do
+            rel="${path#papers/}"
+            top="${rel%%/*}"
+            [[ -z "$top" ]] && continue
+            # Skip if this top-level papers/ folder already existed on the base branch
+            # (i.e. these are just new files inside an existing paper, not a new paper).
+            if git cat-file -e "$BASE_SHA:papers/$top" 2>/dev/null; then
+              continue
+            fi
+            if [[ -z "${seen[$top]:-}" ]]; then
+              seen[$top]=1
+              new_papers+=("$top")
+            fi
+          done
+
+          if [[ ${#new_papers[@]} -eq 0 ]]; then
+            echo "No new paper folders detected in this PR."
+            {
+              echo "papers="
+            } >> "$GITHUB_OUTPUT"
+          else
+            printf 'New paper folder(s) detected: %s\n' "${new_papers[*]}"
+            {
+              echo "papers=${new_papers[*]}"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Smoke test new papers
+        if: steps.detect.outputs.papers != ''
+        run: |
+          set -euo pipefail
+          status=0
+          for paper in ${{ steps.detect.outputs.papers }}; do
+            echo "::group::Smoke test for $paper"
+            if ! scripts/smoke_test_all_papers.sh "$paper"; then
+              status=1
+            fi
+            echo "::endgroup::"
+          done
+          exit $status
+
+      - name: Upload smoke test logs
+        if: always() && steps.detect.outputs.papers != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-test-logs
+          path: .smoke_logs/
+          if-no-files-found: ignore

--- a/.github/workflows/smoke-test-new-papers.yml
+++ b/.github/workflows/smoke-test-new-papers.yml
@@ -145,7 +145,7 @@ jobs:
           status=0
           for paper in ${{ steps.detect.outputs.papers }}; do
             echo "::group::Smoke test for $paper"
-            if ! scripts/smoke_test_all_papers.sh "$paper"; then
+            if ! scripts/smoke_test_all_papers.sh --exact "$paper"; then
               status=1
             fi
             echo "::endgroup::"

--- a/.github/workflows/smoke-test-new-papers.yml
+++ b/.github/workflows/smoke-test-new-papers.yml
@@ -37,23 +37,37 @@ jobs:
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
-          mapfile -t added_paths < <(git diff --name-status --diff-filter=A "$BASE_SHA" "$HEAD_SHA" -- papers/ | awk '{print $2}')
+          mapfile -t added_paths < <(git diff -M --name-status --diff-filter=AR "$BASE_SHA" "$HEAD_SHA" -- papers/ | awk '{print $NF}')
+
+          # Walk up from an added file's directory (in the checked-out HEAD tree) to find the
+          # nearest ancestor that carries the three project markers. This correctly identifies
+          # nested paper suites (e.g. papers/<parent>/<subproject>/) instead of only top-level dirs.
+          find_paper_root() {
+            local candidate="$1"
+            while [[ "$candidate" == papers/* ]]; do
+              if [[ -f "$candidate/cli.json" && -f "$candidate/configs/defaults.json" && -f "$candidate/lib/runner.py" ]]; then
+                echo "$candidate"
+                return 0
+              fi
+              [[ "$candidate" == "papers" ]] && break
+              candidate="$(dirname "$candidate")"
+            done
+            return 1
+          }
 
           declare -A seen
           new_papers=()
           for path in "${added_paths[@]}"; do
-            rel="${path#papers/}"
-            top="${rel%%/*}"
-            [[ -z "$top" ]] && continue
-            # Skip if this top-level papers/ folder already existed on the base branch
-            # (i.e. these are just new files inside an existing paper, not a new paper).
-            if git cat-file -e "$BASE_SHA:papers/$top" 2>/dev/null; then
+            root="$(find_paper_root "$(dirname "$path")")" || continue
+            rel="${root#papers/}"
+            [[ -n "${seen[$rel]:-}" ]] && continue
+            seen[$rel]=1
+            # Skip if this paper root already existed on the base branch (i.e. these are just
+            # new files inside an existing paper, not a new paper).
+            if git cat-file -e "$BASE_SHA:$root" 2>/dev/null; then
               continue
             fi
-            if [[ -z "${seen[$top]:-}" ]]; then
-              seen[$top]=1
-              new_papers+=("$top")
-            fi
+            new_papers+=("$rel")
           done
 
           if [[ ${#new_papers[@]} -eq 0 ]]; then


### PR DESCRIPTION
### Summary
Adds a new GitHub Actions workflow `smoke-test-new-papers.yml` that automatically smoke-tests any paper folder newly introduced by a PR: 

- it installs the paper's dependencies in a new venv, 
- runs its **default config** end-to-end, and runs its **pytest** suite. 

This gives contributors fast feedback that a new reproduction actually runs before merge.

### What's included

- Triggers on PRs touching `papers/**` (targeting `main/master`).
- Gated to **trusted authors (MEMBER/OWNER association)** since the job installs and executes arbitrary PR-supplied dependencies/code and we want only trusted code to run.
- Detect step: diffs base.sha...head.sha
- It fails fast with a **clear error** message and lists required files if a detected paper doesn't follow the expected structure.
- Smoke test step: runs `scripts/smoke_test_all_papers.sh <paper> `per detected paper (venv setup, requirements.txt install, default config run with timeout, pytest).
- Uploads `.smoke_logs` as a build artifact for debugging, regardless of pass/fail.

### How to test
Open/update a PR that adds a new folder under `papers` following the standard structure and confirm the workflow detects it, validates structure, and runs the smoke test.